### PR TITLE
Develop

### DIFF
--- a/locales/ja.json5
+++ b/locales/ja.json5
@@ -3904,7 +3904,7 @@
 	"Shivering dragon egg": "微動するドラゴンの卵",
 	"Krumblor, cookie hatchling": "クランブラー、クッキーのひな",
 	"Krumblor, cookie dragon": "クランブラー、クッキードラゴン",
-	"Train %1": "を鍛えろ",
+	"Train %1": "%1を鍛えろ",
 	"Aura: %1": "オーラ : %1",
 	"Chip it": "ひびを入れろ",
 	"Hatch it": "孵化させろ",


### PR DESCRIPTION
add: DOM構成後に翻訳を適用するinitAfterDOMCreated関数を追加

ブラウザの場合かつ初期化後の場合(基本的にはcreateフック後ですが場合によってはフック前にも初期化後と判定しうるかもしれません)、翻訳を適用し直します。
MODとして公開された状態でのテスト方法がわからなかったのであくまでコンソール上での動作確認しかしておりません、すみません。
実績、アップグレードの概要(desc)の翻訳再適用はまだ実装できておりません。