### PR TITLE
fix: フォーチュン系のニュースのためにアップグレードの置換を変更、翻訳方法を変更 等

### DIFF
--- a/locales/ja.json5
+++ b/locales/ja.json5
@@ -756,7 +756,7 @@
 	"Sugar lumps coalesce <b>a whole lot faster</b>.": "角砂糖の融合が<b>大変早く</b>なる。",
 	"<b>+%1%</b> prestige level effect on CpS.": "名声レベルのCpSへの効果が <b>+%1%</b> される。",
 	"<b>+%1%</b> prestige level effect on CpS.<br><b>+%2%</b> golden cookie effect duration.<br><b>+%3%</b> golden cookie lifespan.": "名声レベルのCpSへの効果が <b>+%1%</b> される。<br>ゴールデンクッキーの効果の時間が <b>+%2%</b> される。<br>ゴールデンクッキーの画面に残る時間が <b>+%3%</b> される。",
-	"Each unspent sugar lump (up to %1) gives <b>+%2% CpS</b>.<div class=\"warning\">Note: this means that spending sugar lumps will decrease your CpS until they grow back.</div>": "未使用の角砂糖1つにつきCpSが <b>+%21%</b> される(上限%1個)。<div class=\"warning\">メモ : このアップグレードにより角砂糖を使用時に、角砂糖が成長して元の数に戻るまでCpSが下がります。</div>",
+	"Each unspent sugar lump (up to %1) gives <b>+%2% CpS</b>.<div class=\"warning\">Note: this means that spending sugar lumps will decrease your CpS until they grow back.</div>": "未使用の角砂糖1つにつきCpSが <b>+%2%</b> される(上限%1個)。<div class=\"warning\">メモ : このアップグレードにより角砂糖を使用時に、角砂糖が成長して元の数に戻るまでCpSが下がります。</div>",
 	"Once an ascension, you may use the \"Sugar frenzy\" switch to <b>triple your CpS</b> for 1 hour, at the cost of <b>1 sugar lump</b>.": "転生1回につき一度、 角砂糖 <b>1個</b> を消費することで、1時間CpSが <b>3倍</b>になる「砂糖フィーバー」スイッチが解禁される。",
 	"Each grandma (up to %1) makes sugar lumps ripen <b>%2</b> sooner.": "角砂糖の成長がグランマ1人につき(最大%1人) <b>%2</b> 早くなる。",
 	"Activating this will <b>triple your CpS</b> for 1 hour, at the cost of <b>1 sugar lump</b>.": "<b>1角砂糖</b> を消費して有効化することで、1時間 <b>CpSが3倍</b> になる。",

--- a/src/common/main.js
+++ b/src/common/main.js
@@ -351,10 +351,6 @@ const betterJapanese = {
             }
         }
 
-        // ニュースのフォーチュンクッキーの表示が壊れる問題を修正
-        let tickerOrigin = eval('Game.getNewTicker.toString()').replace('me.name.indexOf(\'#\')', 'me.dname.indexOf(\'No.\')').replace(/me\.baseDesc/g, 'me.ddesc')
-        eval(`Game.getNewTicker = ${tickerOrigin}`)
-
         // ニュースを英語で出力させるように
         betterJapanese.origins.getNewTicker = Game.getNewTicker
         Game.getNewTicker = function(manual) {
@@ -704,6 +700,14 @@ const betterJapanese = {
         // 動的なニュース(Ticker (Dynamic))のリストが読み込めていなければそのまま返す
         let dynamicLocList = locStrings['Ticker (Dynamic)']
         if (!dynamicLocList) return str
+
+        // フォーチュン系のニュースの場合に翻訳
+        for (let i in Game.Tiers['fortune'].upgrades) {
+			let it = Game.Tiers['fortune'].upgrades[i]
+			if (it.dname.substring('Fortune '.length) + ' : ' + it.baseDesc.substring(it.baseDesc.indexOf('<q>') + 3, it.baseDesc.length - '</q>'.length) === str) {
+                return it.dname.substring(it.dname.indexOf('No.')) + ' : ' + it.baseDesc.substring(it.baseDesc.indexOf('<q>') + 3, it.baseDesc.length - '</q>'.length)
+            }
+		}
 
         // 動的ニュースリストから対象のニュースを探す
         let targetStr = Object.keys(dynamicLocList).find((text) => {

--- a/src/common/main.js
+++ b/src/common/main.js
@@ -286,7 +286,7 @@ const betterJapanese = {
         }
 
         // 一級品の壁紙アソートメントの説明翻訳
-        upgrade = Game.Upgrades['Distinguished wallpaper assortment'].desc = loc('Contains more wallpapers for your background selector.')
+        Game.Upgrades['Distinguished wallpaper assortment'].desc = loc('Contains more wallpapers for your background selector.')
 
         // ゴールデンスイッチの説明翻訳
         let func = function() {

--- a/src/web/rebuild.js
+++ b/src/web/rebuild.js
@@ -25,6 +25,10 @@ function rebuildLocalization() {
     l('ascendButton').outerHTML = `<a id="ascendButton" class="option framed large red" ${Game.getTooltip(`<div style="min-width:300px;text-align:center;font-size:11px;padding:8px;" id="tooltipReincarnate">${loc('Click this once you\'ve bought<br>everything you need!')}</div>`, 'bottom-right')} style="font-size:16px;margin-top:0px;"><span class="fancyText" style="font-size:20px;">${loc('Reincarnate')}</span></a>`
     l('ascendInfo').getElementsByClassName('ascendData')[0].innerHTML = loc('You are ascending.<br>Drag the screen around<br>or use arrow keys!<br>When you\'re ready,<br>click Reincarnate.')
     Game.UpdateAscensionModePrompt()
+    AddEvent(l('ascendButton'), 'click', function() {
+        PlaySound('snd/tick.mp3')
+        Game.Reincarnate()
+    })
     
     // 設定画面オンオフ
     ON = ' ' + loc('ON')
@@ -165,14 +169,14 @@ function rebuildLocalization() {
         let name = result[1].replaceAll('\\\'', '\'')
         let obj = Game.Upgrades[name]
         let pow = typeof (obj.power) === 'function' ? obj.power(obj) : obj.power
-        obj.ddesc = loc('Cookie production multiplier <b>+%1%</b>.', pow)
+        obj.baseDesc = loc('Cookie production multiplier <b>+%1%</b>.', pow)
     }
     
     // シナジー系アップグレード概要
     for (let result of funcInitString.matchAll(/(?<!\/\/)Game\.SynergyUpgrade\('(.+?)(?<!\\)',/g)) {
         let name = result[1].replaceAll('\\\'', '\'')
         let obj = Game.Upgrades[name]
-        obj.ddesc = loc('%1 gain <b>+%2%</b> CpS per %3.', [cap(obj.buildingTie1.plural), 5, obj.buildingTie2.single]) + '<br>' + loc('%1 gain <b>+%2%</b> CpS per %3.', [cap(obj.buildingTie2.plural), 0.1, obj.buildingTie1.single])
+        obj.baseDesc = loc('%1 gain <b>+%2%</b> CpS per %3.', [cap(obj.buildingTie1.plural), 5, obj.buildingTie2.single]) + '<br>' + loc('%1 gain <b>+%2%</b> CpS per %3.', [cap(obj.buildingTie2.plural), 0.1, obj.buildingTie1.single])
     }
     
     // ティアありアップグレード概要
@@ -180,9 +184,9 @@ function rebuildLocalization() {
         let name = result[1].replaceAll('\\\'', '\'')
         let obj = Game.Upgrades[name]
         if (result[3] === '\'fortune\'') {
-            obj.ddesc = loc('%1 are <b>%2%</b> more efficient and <b>%3%</b> cheaper.', [cap(obj.buildingTie1.plural), 7, 7])
+            obj.baseDesc = loc('%1 are <b>%2%</b> more efficient and <b>%3%</b> cheaper.', [cap(obj.buildingTie1.plural), 7, 7])
         } else {
-            obj.ddesc = loc('%1 are <b>twice</b> as efficient.', cap(obj.buildingTie1.plural))
+            obj.baseDesc = loc('%1 are <b>twice</b> as efficient.', cap(obj.buildingTie1.plural))
         }
     }
     
@@ -192,9 +196,9 @@ function rebuildLocalization() {
         let building = Game.Objects[name]
         let obj = Game.Upgrades['Unshackled ' + building.bplural]
         if (name === 'Cursor') {
-            obj.ddesc = getStrThousandFingersGain(25)
+            obj.baseDesc = getStrThousandFingersGain(25)
         } else {
-            obj.ddesc = loc('Tiered upgrades for <b>%1</b> provide an extra <b>+%2%</b> production.<br>Only works with unshackled upgrade tiers.', [cap(building.plural), Math.round((building.id == 1 ? 0.5 : (20 - building.id) * 0.1) * 100)])
+            obj.baseDesc = loc('Tiered upgrades for <b>%1</b> provide an extra <b>+%2%</b> production.<br>Only works with unshackled upgrade tiers.', [cap(building.plural), Math.round((building.id == 1 ? 0.5 : (20 - building.id) * 0.1) * 100)])
         }
     }
     
@@ -208,13 +212,13 @@ function rebuildLocalization() {
             obj = Game.Upgrades['Unshackled ' + Game.Tiers[tier].name.toLowerCase()]
         }
         tier = Game.Tiers[tier]
-        obj.ddesc = loc('Unshackles all <b>%1-tier upgrades</b>, making them more powerful.<br>Only applies to unshackled buildings.', cap(loc('[Tier]' + tier.name, 0, tier.name)))
+        obj.baseDesc = loc('Unshackles all <b>%1-tier upgrades</b>, making them more powerful.<br>Only applies to unshackled buildings.', cap(loc('[Tier]' + tier.name, 0, tier.name)))
     }
     
     // グランマシナジー系アップグレード概要
     for (let result of funcInitString.matchAll(/(?<!\/\/)Game\.GrandmaSynergy\('(.+?)(?<!\\)',/g)) {
         let obj = Game.Upgrades[result[1].replaceAll('\\\'', '\'')]
-        obj.ddesc = loc('%1 are <b>twice</b> as efficient.', cap(Game.Objects['Grandma'].plural)) + ' ' + loc('%1 gain <b>+%2%</b> CpS per %3.', [cap(obj.buildingTie.plural), 1, loc('%1 grandma', LBeautify(obj.buildingTie.id - 1))])
+        obj.baseDesc = loc('%1 are <b>twice</b> as efficient.', cap(Game.Objects['Grandma'].plural)) + ' ' + loc('%1 gain <b>+%2%</b> CpS per %3.', [cap(obj.buildingTie.plural), 1, loc('%1 grandma', LBeautify(obj.buildingTie.id - 1))])
     }
     
     let angelUpgrades = ['Angels', 'Archangels', 'Virtues', 'Dominions', 'Cherubim', 'Seraphim', 'God']// 天使系アップグレード
@@ -224,15 +228,15 @@ function rebuildLocalization() {
     for (let result of funcInitString.matchAll(/(?<!\/\/|=)new Game\.Upgrade\('(.+?)(?<!\\)',(.+?)(?<!\([^,\)]+?),((?:[^,]|(?:(?<=\([^\)]+?),(?=[^\(]+?\))))+)(?<!\([^,\)]+?),(?:\[\d+?,\d+?\]|Game.GetIcon\(.+?\))(?:,function\(\){.+?})?\);/g)) {
         let obj = Game.Upgrades[result[1].replaceAll('\\\'', '\'')]
         if (obj.name.indexOf('Permanent upgrade slot ') == 0) {
-            obj.ddesc = loc('Placing an upgrade in this slot will make its effects <b>permanent</b> across all playthroughs.')
+            obj.baseDesc = loc('Placing an upgrade in this slot will make its effects <b>permanent</b> across all playthroughs.')
         } else if (angelUpgrades.includes(obj.name)) {
             let match = result[2].match(/desc\((\d+?),(\d+?)\)/)
-            obj.ddesc = loc('You gain another <b>+%1%</b> of your regular CpS while the game is closed, for a total of <b>%2%</b>.', [Number(match[1]), Number(match[2])])
+            obj.baseDesc = loc('You gain another <b>+%1%</b> of your regular CpS while the game is closed, for a total of <b>%2%</b>.', [Number(match[1]), Number(match[2])])
         } else if (demonUpgrades.includes(obj.name)) {
             let match = result[2].match(/desc\((\d+?)\)/)
-            obj.ddesc = loc('You retain optimal cookie production while the game is closed for twice as long, for a total of <b>%1</b>.', Game.sayTime(Number(match[1]) * 60 * 60 * Game.fps, -1))
+            obj.baseDesc = loc('You retain optimal cookie production while the game is closed for twice as long, for a total of <b>%1</b>.', Game.sayTime(Number(match[1]) * 60 * 60 * Game.fps, -1))
         } else {
-            obj.ddesc = eval(result[2])
+            obj.baseDesc = eval(result[2])
         }
     }
     
@@ -241,12 +245,13 @@ function rebuildLocalization() {
         let obj = Game.Upgrades[upg]
         let quote = loc(FindLocStringByPart('Upgrade quote ' + obj.id))
         if (typeof (quote) !== 'undefined') {
-            let qpos = obj.ddesc.indexOf('<q>')
+            let qpos = obj.baseDesc.indexOf('<q>')
             if (qpos >= 0) {
-                obj.ddesc = obj.ddesc.substring(0, qpos)
+                obj.ddesc = obj.baseDesc.substring(0, qpos)
             }
-            obj.ddesc += `<q>${quote}</q>`
+            obj.baseDesc += `<q>${quote}</q>`
         }
+        obj.ddesc = obj.baseDesc
     }
     
     // ティアあり実績概要

--- a/src/web/rebuild.js
+++ b/src/web/rebuild.js
@@ -247,7 +247,7 @@ function rebuildLocalization() {
         if (typeof (quote) !== 'undefined') {
             let qpos = obj.baseDesc.indexOf('<q>')
             if (qpos >= 0) {
-                obj.ddesc = obj.baseDesc.substring(0, qpos)
+                obj.baseDesc = obj.baseDesc.substring(0, qpos)
             }
             obj.baseDesc += `<q>${quote}</q>`
         }


### PR DESCRIPTION
fix: フォーチュン系のニュースのためにアップグレードの置換を変更
fix: フォーチュン系のニュースの翻訳方法を変更
fix: DOM構築後の転生画面の再翻訳により転生ボタンが無効化されていた現象を修正

getNewTickerを可能な限り変更しないよう翻訳していたため、フォーチュン系のニュースについてもそのように対応してみました。
ただし実行速度は修正後の方がやや落ちると考えられる(わずかだとは思いますが)ため、どちらを採用するかはおまかせします。
また、アップグレード、実績のddescやbaseDescがどう使い分けされているかあやふやなので一応双方baseDescとddescどちらも置き換える方法で統一しております。